### PR TITLE
increase SPI SCK rate to max supported (f_osc/2)

### DIFF
--- a/spi_flash_programmer.ino
+++ b/spi_flash_programmer.ino
@@ -54,11 +54,10 @@ void setup()
   pinMode(SLAVESELECT,OUTPUT);
     
   digitalWrite(SLAVESELECT,HIGH); //disable device 
-  // SPCR = 01010000
   //interrupt disabled,spi enabled,msb 1st,master,clk low when idle,
-  //sample on leading edge of clk,system clock/4 rate (fastest)
-  //SPCR = (1<<SPE)|(1<<MSTR);
-  SPCR = (1<<SPE)|(1<<MSTR)|(1<<SPI2X);
+  //sample on leading edge of clk,system clock/2 rate (fastest)
+  SPCR = (1<<SPE)|(1<<MSTR);
+  SPSR = (1<<SPI2X);
   
   byte clr;
   clr=SPSR;


### PR DESCRIPTION
This patch corrects the following two issues:
- incorrect comment claiming "fastest" SCK was f_osc/4, when it's in fact f_osc/2;
- fixes misapplication of SPI2X bit of SPSR register to SPCR, causing operation with reduces SCK rate of f_osc/16 (see ATmega328p datasheet p.222)