### PR TITLE
Ice40hx8k prog

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ The board is connected using the UEXT connector.
 > python3 spi_flash_programmer_client.py -d COM1 --io 0x2 --value 0x0 set-output
 # Set CS/SS to PIN 13/0xd
 > python3 spi_flash_programmer_client.py -d COM1 --io 0xd set-cs-io
-# power cycle the EVB, check if STATUS register is readable
-> python3 spi_flash_programmer_client.py -d COM1 --io 0xd status-register
+# power cycle the EVB, check if ID register is readable
+> python3 spi_flash_programmer_client.py -d COM1 id-register
 # program the bitmap
 > python3 spi_flash_programmer_client.py -d COM1 -l -1 --pad 0xff -f toplevel_bitmap.bin write
 ```

--- a/README.md
+++ b/README.md
@@ -93,29 +93,31 @@ Connected to 'SPI Flash programmer v1.0'
 usage: spi_flash_programmer_client.py [-h] [-d DEVICE] [-f FILENAME]
                                       [-l LENGTH] [--rate BAUD_RATE]
                                       [--flash-offset FLASH_OFFSET]
-                                      [--file-offset FILE_OFFSET]
-                                      {ports,write,read,verify,erase}
+                                      [--file-offset FILE_OFFSET] [--pad PAD]
+                                      [--debug {off,normal,verbose}] [--io IO]
+                                      [--value VALUE]
+                                      {ports,write,read,verify,erase,enable-protection,disable-protection,check-protection,status-register,id-register,set-cs-io,set-output}
 
 Interface with an Arduino-based SPI flash programmer
 
 positional arguments:
-  {ports,write,read,verify,erase,
-   enable-protection,disable-protection,check-protection,
-   status-register,
-   set-cs-io,set-output}
+  {ports,write,read,verify,erase,enable-protection,disable-protection,check-protection,status-register,id-register,set-cs-io,set-output}
                         command to execute
 
 optional arguments:
   -h, --help            show this help message and exit
   -d DEVICE             serial port to communicate with
   -f FILENAME           file to read from / write to
-  -l LENGTH             length to read/write in kibi bytes (factor 1024)
+  -l LENGTH             length to read/write in bytes, use -1 to write entire
+                        file
   --rate BAUD_RATE      baud-rate of serial connection
   --flash-offset FLASH_OFFSET
                         offset for flash read/write in bytes
   --file-offset FILE_OFFSET
                         offset for file read/write in bytes
   --pad PAD             pad value if file is not algined with SECTOR_SIZE
+  --debug {off,normal,verbose}
+                        enable debug output
   --io IO               IO pin used for set-cs-io and set-output
   --value VALUE         value used for set-output
 ```

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ Connected to 'SPI Flash programmer v1.0'
 Connected to 'SPI Flash programmer v1.0'
 [###########                     ] 383/1024 - 00:01:13
 
+# Set IO Pin value
+# Example: IO pin 0x2, set to LOW
+> python3 spi_flash_programmer_client.py \
+>   -d COM1 --io 0x2 --value 0x0 set-output
+
+# Override ChipSelect pin
+# Example: use IO pin 13/0xd
+> python3 spi_flash_programmer_client.py \
+>   -d COM1 --io 0xd set-cs-io
+
 # Help text
 > python3 spi_flash_programmer_client.py -h
 usage: spi_flash_programmer_client.py [-h] [-d DEVICE] [-f FILENAME]
@@ -89,7 +99,10 @@ usage: spi_flash_programmer_client.py [-h] [-d DEVICE] [-f FILENAME]
 Interface with an Arduino-based SPI flash programmer
 
 positional arguments:
-  {ports,write,read,verify,erase}
+  {ports,write,read,verify,erase,
+   enable-protection,disable-protection,check-protection,
+   status-register,
+   set-cs-io,set-output}
                         command to execute
 
 optional arguments:
@@ -102,6 +115,9 @@ optional arguments:
                         offset for flash read/write in bytes
   --file-offset FILE_OFFSET
                         offset for file read/write in bytes
+  --pad PAD             pad value if file is not algined with SECTOR_SIZE
+  --io IO               IO pin used for set-cs-io and set-output
+  --value VALUE         value used for set-output
 ```
 
 Troubleshooting
@@ -150,3 +166,18 @@ I guess if you do a system upgrade which puts the kernel image somewhere after t
 
 If you try this, let me know!
 
+Flashing iCE40HX8K-EVB from Olimex
+==================================
+This example uses the OLIMEXINO-32U4 to flash a Olimex iCE40HX8K-EVB. The steps should also work with a iCE40HX1K-EVB.
+
+The board is connected using the UEXT connector.
+```bash
+# Set iCE40-CRESET LOW - PIN 0x2
+> python3 spi_flash_programmer_client.py -d COM1 --io 0x2 --value 0x0 set-output
+# Set CS/SS to PIN 13/0xd
+> python3 spi_flash_programmer_client.py -d COM1 --io 0xd set-cs-io
+# power cycle the EVB, check if STATUS register is readable
+> python3 spi_flash_programmer_client.py -d COM1 --io 0xd status-register
+# program the bitmap
+> python3 spi_flash_programmer_client.py -d COM1 -l -1 --pad 0xff -f toplevel_bitmap.bin write
+```

--- a/spi_flash_programmer.ino
+++ b/spi_flash_programmer.ino
@@ -245,6 +245,7 @@ void loop()
     Serial.println("  u         : disable write protection");
     Serial.println("  x         : check write protection");
     Serial.println("  y         : read status register");
+    Serial.println("  i         : read id register");
     Serial.println();
     Serial.println("  h         : print buffer CRC-32");
     Serial.println("  l         : display the buffer (in hex)");

--- a/spi_flash_programmer.ino
+++ b/spi_flash_programmer.ino
@@ -18,6 +18,7 @@
 #define COMMAND_WRITE_PROTECTION_DISABLE 'u'
 #define COMMAND_WRITE_PROTECTION_CHECK 'x'
 #define COMMAND_STATUS_REGISTER_READ 'y'
+#define COMMAND_ID_REGISTER_READ 'i'
 #define COMMAND_ERROR '!'
 #define COMMAND_SET_CS '*'
 #define COMMAND_SET_OUTPUT 'o'
@@ -191,6 +192,11 @@ void loop()
   case COMMAND_STATUS_REGISTER_READ:
     Serial.print(COMMAND_STATUS_REGISTER_READ); // Echo OK
     impl_status_register_read();
+    break;
+    
+  case COMMAND_ID_REGISTER_READ:
+    Serial.print(COMMAND_ID_REGISTER_READ); // Echo OK
+    impl_jedec_id_read();
     break;
 
   case COMMAND_SET_CS:
@@ -502,6 +508,7 @@ uint32_t crc_buffer(void)
 #define WRITE        0x02
 #define SECTOR_ERASE 0x20
 #define CHIP_ERASE   0xC7
+#define JEDECIDR     0x9F
 
 #define WPS          0x040000
 #define CP           0x000400
@@ -742,4 +749,15 @@ void impl_status_register_read(void)
   write_hex_u8(statusRegister);
   write_hex_u8(statusRegister2);
   write_hex_u8(statusRegister3);
+}
+
+void impl_jedec_id_read(void)
+{
+  digitalWrite(nCsIo, LOW);
+  SPI.transfer(JEDECIDR);
+  write_hex_u8(0x03);
+  write_hex_u8(SPI.transfer(0x0));
+  write_hex_u8(SPI.transfer(0x0));
+  write_hex_u8(SPI.transfer(0x0));
+  digitalWrite(nCsIo, HIGH);
 }

--- a/spi_flash_programmer_client.py
+++ b/spi_flash_programmer_client.py
@@ -451,6 +451,9 @@ class SerialProgrammer:
             if flash_offset % self.sector_size != 0:
                 logError('flash_offset must be a multiple of the sector size %d' % self.sector_size)
                 return False
+        elif not ((0x0 <= pad) and (pad <= 0xff)):
+            logError('pad must be in range 0x00--0xff')
+            return False
 
         if file_offset < 0:
             logError('file_offset must be a positive value or 0')
@@ -757,7 +760,7 @@ def main():
     parser.add_argument('-f', dest='filename', default='flash.bin',
                         help='file to read from / write to')
     parser.add_argument('-l', type=hex_dec, dest='length', default=DEFAULT_FLASH_SIZE,
-                        help='length to read/write in bytes')
+                        help='length to read/write in bytes, use -1 to write entire file')
 
     parser.add_argument('--rate', type=int, dest='baud_rate', default=115200,
                         help='baud-rate of serial connection')
@@ -766,11 +769,11 @@ def main():
     parser.add_argument('--file-offset', type=hex_dec, dest='file_offset', default=0,
                         help='offset for file read/write in bytes')
     parser.add_argument('--pad', type=hex_dec, default=None,
-                        help='pad if file-size is != SECTOR_SIZE')
+                        help='pad value if file is not algined with SECTOR_SIZE')
     parser.add_argument('--debug', choices=('off', 'normal', 'verbose'), default='off',
                         help='enable debug output')
     parser.add_argument('--io', type=hex_dec, default=None,
-                        help="io used for set-cs-io and set-output")
+                        help="IO pin used for set-cs-io and set-output")
     parser.add_argument('--value', type=hex_dec, default=None,
                         help="value used for set-output")
 

--- a/spi_flash_programmer_client.py
+++ b/spi_flash_programmer_client.py
@@ -23,6 +23,7 @@ COMMAND_WRITE_PROTECTION_ENABLE = 'p'
 COMMAND_WRITE_PROTECTION_DISABLE = 'u'
 COMMAND_WRITE_PROTECTION_CHECK = 'x'
 COMMAND_STATUS_REGISTER_READ = 'y'
+COMMAND_ID_REGISTER_READ = 'i'
 
 COMMAND_SET_CS_IO = '*'
 COMMAND_SET_OUTPUT = 'o'
@@ -165,6 +166,11 @@ class SerialProgrammer:
                 return data[:-len(message)]
 
         return None
+        
+    def _dump(self, data_str):
+        for offset, data_row in [(i, data_str[i:i+16]) for i in range(0, len(data_str), 16)]:
+            logMessage('%08x: %s' % (offset, ' '.join([data_row[i:i+2] for i in range(0, 16, 2)])))
+        return
 
     def _sendCommand(self, command):
         self._debug('Send: \'%s\'' % command, DEBUG_VERBOSE)
@@ -431,6 +437,42 @@ class SerialProgrammer:
 
         return message.decode(ENCODING)
 
+    def _read_register(self, cmd, name):
+        """Generic read register function, send cmd and read a <CMD><LEN><DATA> response"""
+        self._sendCommand(cmd)
+        if not self._waitForMessage(cmd):
+            self._debug('Invalid / no response for %s command' % (name,))
+            logError('Invalid response')
+            return None
+
+        length_str = self._readExactly(2).decode(ENCODING)
+        if length_str is None:
+            self._debug('Invalid / no response for %s length' % (name,))
+            logError('Invalid response')
+            return None
+
+        try:
+            length = int(length_str, 16)
+        except ValueError:
+            self._debug('Could not decode %s length' % (name,))
+            logError('Invalid register length')
+            return None
+
+        data_str = self._readExactly(length * 2).decode(ENCODING)
+        if data_str is None:
+            self._debug('Invalid / no response for %s check' % (name,))
+            logError('Invalid response')
+            return None
+
+        try:  # Check if valid data
+            decoded_data = binascii.a2b_hex(data_str)
+        except TypeError:
+            self._debug('Could not decode %s content' % (name))
+            logError('Invalid response')
+            return None
+
+        return data_str
+
     def hello(self):
         """Send a hello message and print the retrieved version string"""
         version = self._hello()
@@ -668,42 +710,21 @@ class SerialProgrammer:
     def read_status_register(self):
         """Reads the status register contents"""
         self._debug('Command: STATUS_REGISTER')
-
-        self._sendCommand(COMMAND_STATUS_REGISTER_READ)
-        if not self._waitForMessage(COMMAND_STATUS_REGISTER_READ):
-            self._debug('Invalid / no response for STATUS_REGISTER command')
-            logError('Invalid response')
+        data = self._read_register(COMMAND_STATUS_REGISTER_READ, 'STATUS_REGISTER')
+        if data==None:
             return True
+        
+        self._dump(data)
+        return True
 
-        length_str = self._readExactly(2).decode(ENCODING)
-        if length_str is None:
-            self._debug('Invalid / no response for status register length')
-            logError('Invalid response')
+    def read_id_register(self):
+        """Reads the id register contents"""
+        self._debug('Command: ID_REGISTER')
+        data = self._read_register(COMMAND_ID_REGISTER_READ, 'ID_REGISTER')
+        if data==None:
             return True
-
-        try:
-            length = int(length_str, 16)
-        except ValueError:
-            self._debug('Could not decode status register length')
-            logError('Invalid register length')
-            return True
-
-        status_str = self._readExactly(length * 2).decode(ENCODING)
-        if status_str is None:
-            self._debug('Invalid / no response for status register check')
-            logError('Invalid response')
-            return True
-
-        try:  # Check if valid status data
-            decoded_status = binascii.a2b_hex(status_str)
-        except TypeError:
-            self._debug('Could not decode status register content')
-            logError('Invalid response')
-            return True
-
-        for offset, status_row in [(i, status_str[i:i+16]) for i in range(0, len(status_str), 16)]:
-            logMessage('%08x: %s' % (offset, ' '.join([status_row[i:i+4] for i in range(0, 16, 4)])))
-
+        
+        self._dump(data)
         return True
 
     def set_cs_io(self, io):
@@ -779,7 +800,7 @@ def main():
 
     parser.add_argument('command', choices=('ports', 'write', 'read', 'verify', 'erase',
                                             'enable-protection', 'disable-protection', 'check-protection',
-                                            'status-register', 'set-cs-io', 'set-output'),
+                                            'status-register', 'id-register', 'set-cs-io', 'set-output'),
                         help='command to execute')
 
     args = parser.parse_args()
@@ -817,6 +838,9 @@ def main():
     def read_status_register(args, prog):
         return prog.read_status_register()
 
+    def read_id_register(args, prog):
+        return prog.read_id_register()
+
     def set_cs_io(args, prog):
         return prog.set_cs_io(args.io)
 
@@ -832,6 +856,7 @@ def main():
             'disable-protection': disable_protection,
             'check-protection': check_protection,
             'status-register': read_status_register,
+            'id-register': read_id_register,
             'set-cs-io': set_cs_io,
             'set-output': set_output
         }


### PR DESCRIPTION
Hi,
I made the following extensions to spi-flash-programmer. The context is that I am using it in conjunction with OLIMEXINO-32u4 to program a Olimex iCE40HX8K-EVB.
  1) add a generic functionality to set specific output pins, accessible via terminal as well as python
  2) add a generic function to set a custom Chip-Select/Slave-Select, thus we can access multiple SPI chips without re-wiring
  3) make all parameters parseable as decimal as well as hexadecimal
  4) introduce parameter --pad which allows to flash a file not algined to sectorsize
  5) allow paramter length to be -1 => flash the complete file
  6) introduce a function to read the JEDEC Manufacturer and Device ID
