### PR TITLE
Restore SPI back to F_CPU/2

### DIFF
--- a/spi_flash_programmer.ino
+++ b/spi_flash_programmer.ino
@@ -40,7 +40,8 @@
 #define SECTOR_SIZE 4096
 #define PAGE_SIZE 256
 #define SERIAL_RATE 115200
-#define SPI_SPEED F_CPU/32
+// Use maximum speed with F_CPU / 2
+#define SPI_SPEED F_CPU/2
 
 void dump_buffer(void);
 void dump_buffer_crc(void);
@@ -80,7 +81,7 @@ void setup()
 {
   nCsIo = SS;
 
-  // Use maximum speed with F_CPU / 2
+  // Setup SPI
   SPISettings settingsA(SPI_SPEED, MSBFIRST, SPI_MODE0);
   uint16_t i;
 


### PR DESCRIPTION
I had previously left it as /32 due to using a different MCU with a higher clock.

Sorry about that, didn't notice. Should keep at at /2 for Arduino